### PR TITLE
Optimize exercise 1.4

### DIFF
--- a/ch01/exercise_01_04.go
+++ b/ch01/exercise_01_04.go
@@ -25,55 +25,53 @@ import (
 )
 
 func main() {
-	counts := make(map[string]int)
-	lines2fnames := make(map[string]map[string]bool)
+	lines2fnames := make(map[string]map[string]int)
 	fnames := os.Args[1:]
 
 	if len(fnames) == 0 {
-		countLines("stdin", os.Stdin, counts, lines2fnames)
+		countLines("stdin", os.Stdin, lines2fnames)
 	} else {
-		countLinesForFnames(fnames, counts, lines2fnames)
+		countLinesForFnames(fnames, lines2fnames)
 	}
-	printDups(counts, lines2fnames)
+	printDups(lines2fnames)
 }
 
-func countLines(fname string, f *os.File, counts map[string]int, lines2fnames map[string]map[string]bool) {
+func countLines(fname string, f *os.File, lines2fnames map[string]map[string]int) {
 	input := bufio.NewScanner(f)
 
 	for input.Scan() {
 		line := input.Text()
-
-		counts[line]++
-
-		_, ok := lines2fnames[line]
-		if !ok {
-			lines2fnames[line] = make(map[string]bool)
+		if len(lines2fnames[line]) == 0 {
+			lines2fnames[line] = make(map[string]int)
 		}
-
-		lines2fnames[line][fname] = true
+		lines2fnames[line][fname]++
 	}
 	// Ignoring potential errors from input.Err(), as in the original dup2.
 }
 
-func countLinesForFnames(fnames []string, counts map[string]int, lines2fnames map[string]map[string]bool) {
+func countLinesForFnames(fnames []string, lines2fnames map[string]map[string]int) {
 	for _, fname := range fnames {
 		f, err := os.Open(fname)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dup2: %v\n", err)
 			continue
 		}
-		countLines(fname, f, counts, lines2fnames)
+		countLines(fname, f, lines2fnames)
 		f.Close()
 	}
 }
 
-func printDups(counts map[string]int, lines2fnames map[string]map[string]bool) {
-	for line, n := range counts {
-		if n > 1 {
-			fmt.Printf("%d\t%s\n", n, line)
-			for fname := range lines2fnames[line] {
+func printDups(lines2fnames map[string]map[string]int) {
+	for line, files := range lines2fnames {
+		total := 0
+		for _, count := range files {
+			total += count
+		}
+		if total > 1 {
+			fmt.Printf("%d\t%s\n", total, line)
+			for fname, _ := range files {
 				fmt.Println(fname)
-			}
+			}			
 		}
 	}
 }


### PR DESCRIPTION
Optimize exercise 1.4 by eliminating the 'counts' map and keep the 'lines2fnames' only, we can use 'lines2fnames' map to hold the line files with their count and use it later to print the duplicates